### PR TITLE
Fix typo in projects.json

### DIFF
--- a/content/projects.json
+++ b/content/projects.json
@@ -41,7 +41,7 @@
         "name": "LAION5B High-Res",
         "modality": "image/text",
         "status": "Released",
-        "desc": "A subset of the LAION5B database, with high resolution images oveer 1024x1024, containing 170 million samples.",
+        "desc": "A subset of the LAION5B database, with high resolution images over 1024x1024, containing 170 million samples.",
         "link": "https://huggingface.co/datasets/laion/laion-high-resolution"
       },
       {


### PR DESCRIPTION
I found this typo while reading the website:
https://laion.ai/projects/

Additionally, we can replace `x` with `×`, but I'm not sure if you will be comfortable with this change.

Also, I found that half of the items are not clickable but still show cursor: pointer, but I'm unsure if we should fix it.